### PR TITLE
fix fetching Wannier90

### DIFF
--- a/install/plugins_list
+++ b/install/plugins_list
@@ -28,7 +28,7 @@ YAMBO_URL=http://www.yambo-code.org/files/yambo-stable-latest.tar.gz
 #
 # Package maintainer: 
 W90=wannier90-3.0.0
-W90_URL=https://github.com/wannier-developers/wannier90/archive/v3.0.0.tar.gz
+W90_URL=https://codeload.github.com/wannier-developers/wannier90/tar.gz/v3.0.0
 #
 # Package maintainer: Layla Martin-Samos
 SAX=sax-2.0.3


### PR DESCRIPTION
"make all" in EPW failed because a tar file of wannier90 was fetched but it was treated as gzipped tar.
This commit fixes this problem.